### PR TITLE
Rename shapeColour property to colour

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Prompt.ask()
                 shape = new Triangle();
                 break;
         }
-        shape.shapeColour = result.shapeColour;
+        shape.colour = result.shapeColour;
         shape.font = {colour: result.fontColour};
         shape.text = result.text;
 

--- a/lib/shapes.js
+++ b/lib/shapes.js
@@ -1,7 +1,7 @@
 class Shape {
-    constructor(shapeColour = Shape.default.shapeColour, font = structuredClone(Shape.default.font)) {
+    constructor(shapeColour = Shape.default.colour, font = structuredClone(Shape.default.font)) {
         this._text = '';
-        this.shapeColour = shapeColour;
+        this.colour = shapeColour;
         this._font = font;
     }
 
@@ -55,7 +55,7 @@ class Shape {
             width: 300,
             height: 200
         },
-        shapeColour: "#000000",
+        colour: "#000000",
         font: {
             family: 'sans-serif',
             size: 60,
@@ -125,7 +125,7 @@ class Shape {
 class Square extends Shape {
     constructor(start = structuredClone(Shape.default.square.start), 
                 dimensions = structuredClone(Shape.default.square.dimensions), 
-                shapeColour = Shape.default.shapeColour,
+                shapeColour = Shape.default.colour,
                 font = structuredClone(Shape.default.font)) {
         super(shapeColour, font);
         this._start = start;
@@ -141,14 +141,14 @@ class Square extends Shape {
     }
 
     draw() {
-        return `<rect width="${this.dimensions.x}" height="${this.dimensions.y}" x="${this.start.x}" y="${this.start.y}" fill="${this.shapeColour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
+        return `<rect width="${this.dimensions.x}" height="${this.dimensions.y}" x="${this.start.x}" y="${this.start.y}" fill="${this.colour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
     }
 }
 
 class Circle extends Shape {
     constructor(centre = structuredClone(Shape.default.circle.centre),
                 radius = structuredClone(Shape.default.circle.radius),
-                shapeColour = Shape.default.shapeColour,
+                shapeColour = Shape.default.colour,
                 font = structuredClone(Shape.default.font)) {
         super(shapeColour, font);
         this._centre = centre;
@@ -160,13 +160,13 @@ class Circle extends Shape {
     }
 
     draw() {
-        return `<circle cx="${this.centre.x}" cy="${this.centre.y}" r="${this.radius}" fill="${this.shapeColour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
+        return `<circle cx="${this.centre.x}" cy="${this.centre.y}" r="${this.radius}" fill="${this.colour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
     }
 }
 
 class Triangle extends Shape {
     constructor(points = structuredClone(Shape.default.triangle.points),
-                shapeColour = Shape.default.shapeColour,
+                shapeColour = Shape.default.colour,
                 font = structuredClone(Shape.default.font)) {
         super(shapeColour, font);
         this._points = points;
@@ -185,7 +185,7 @@ class Triangle extends Shape {
     }
 
     draw() {
-        return `<polygon points="${this.points[1].join(' ')} ${this.points[2].join(' ')} ${this.points[3].join(' ')}" fill="${this.shapeColour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
+        return `<polygon points="${this.points[1].join(' ')} ${this.points[2].join(' ')} ${this.points[3].join(' ')}" fill="${this.colour}" />\n<text x="${this.font.position.x}" y="${this.font.position.y}" font-size="${this.font.size}" text-anchor="${this.font.anchor}" fill="${this.font.colour}" font-family="${this.font.family}">${this.text}</text>`
     }
 }
 

--- a/tests/shapes.test.js
+++ b/tests/shapes.test.js
@@ -4,8 +4,8 @@ describe("Shapes", () => {
     describe("Shape", () => {
         const test = new Shape();
         it('has a colour property, and returns a default colour from empty declaration', () => {
-            expect(test).toHaveProperty('shapeColour');
-            expect(test.shapeColour).toEqual('#000000');
+            expect(test).toHaveProperty('colour');
+            expect(test.colour).toEqual('#000000');
         });
         it('has a text property, and returns an empty string from empty declaration', () => {
             expect(test).toHaveProperty('text');
@@ -58,7 +58,7 @@ Not implemented
     describe("Square", () => {
         const test = new Square();
         it('inherits from Shape', () => {
-            expect(test).toHaveProperty('shapeColour');
+            expect(test).toHaveProperty('colour');
             expect(test).toHaveProperty('text');
             expect(test).toHaveProperty('font');
         });
@@ -86,7 +86,7 @@ Not implemented
     describe("Circle", () => {
         const test = new Circle();
         it('inherits from Shape', () => {
-            expect(test).toHaveProperty('shapeColour');
+            expect(test).toHaveProperty('colour');
             expect(test).toHaveProperty('text');
             expect(test).toHaveProperty('font');
         });
@@ -113,7 +113,7 @@ Not implemented
     describe("Triangle", () => {
         const test = new Triangle();
         it('inherits from Shape', () => {
-            expect(test).toHaveProperty('shapeColour');
+            expect(test).toHaveProperty('colour');
             expect(test).toHaveProperty('text');
             expect(test).toHaveProperty('font');
         });


### PR DESCRIPTION
shapeColour didn't make sense as an internal property for shape, since the colour for font is under the font object property, and is also named colour. This makes the names just a tad more consistent.